### PR TITLE
fix: properly serialize JSON fields on insert

### DIFF
--- a/.changeset/pink-rules-work.md
+++ b/.changeset/pink-rules-work.md
@@ -1,0 +1,5 @@
+---
+"fumadb": patch
+---
+
+fix: properly serialize JSON fields on insert

--- a/packages/fumadb/src/adapters/kysely/query.ts
+++ b/packages/fumadb/src/adapters/kysely/query.ts
@@ -188,8 +188,9 @@ export function fromKysely(
         value = col.generateDefaultValue();
       }
 
-      if (value !== undefined)
+      if (value !== undefined) {
         result[col.names.sql] = serialize(value, col, provider);
+      }
     }
 
     return result;

--- a/packages/fumadb/src/schema/serialize.ts
+++ b/packages/fumadb/src/schema/serialize.ts
@@ -263,7 +263,7 @@ export function serialize(
 ) {
   if (value === null) return null;
 
-  if (!supportJson.includes(provider) && col.type === "json") {
+  if (col.type === "json") {
     return JSON.stringify(value);
   }
 

--- a/packages/fumadb/test/query/query.schema.ts
+++ b/packages/fumadb/test/query/query.schema.ts
@@ -17,6 +17,11 @@ export const v1 = schema({
       // for testing one-to-one
       mentionId: column("mention_id", "varchar(255)").nullable().unique(),
     }),
+    posts: table("posts", {
+      id: idColumn("id", "uuid"),
+      title: column("title", "string"),
+      metadata: column("metadata", "json"),
+    }),
   },
   relations: {
     users: ({ many }) => ({

--- a/packages/fumadb/test/query/query.test.ts
+++ b/packages/fumadb/test/query/query.test.ts
@@ -285,3 +285,58 @@ test.each(prismaTests)(
     }
   }
 );
+
+test.each(kyselyTests)(
+  "json column with empty object - kysely ($provider)",
+  { timeout: Infinity },
+  async (item) => {
+    await resetDB(item.provider);
+    const client = myDB.client(
+      kyselyAdapter({
+        db: item.db,
+        provider: item.provider,
+      })
+    );
+
+    const migrator = await client.createMigrator();
+    await migrator.migrateToLatest().then((res) => res.execute());
+
+    const orm = client.orm("1.0.0");
+
+    // Test 1: Insert with empty object metadata
+    const result1 = await orm.create("posts", {
+      id: "00000000-0000-0000-0000-000000000001",
+      title: "Post with empty metadata",
+      metadata: {},
+    });
+
+    expect(result1).toEqual({
+      id: "00000000-0000-0000-0000-000000000001",
+      title: "Post with empty metadata",
+      metadata: {},
+    });
+
+    // Test 2: createMany with empty objects
+    await orm.createMany("posts", [
+      {
+        id: "00000000-0000-0000-0000-000000000002",
+        title: "Post 2",
+        metadata: {},
+      },
+      {
+        id: "00000000-0000-0000-0000-000000000003",
+        title: "Post 3",
+        metadata: { views: 100 },
+      },
+    ]);
+
+    const all = await orm.findMany("posts", {
+      orderBy: ["id", "asc"],
+    });
+
+    expect(all).toHaveLength(3);
+    expect(all[0]?.metadata).toEqual({});
+    expect(all[1]?.metadata).toEqual({});
+    expect(all[2]?.metadata).toEqual({ views: 100 });
+  }
+);


### PR DESCRIPTION
## as-is
<img width="446" height="319" alt="image" src="https://github.com/user-attachments/assets/72b8d68f-a574-40f7-aac5-35e4f30a76b6" />

## to-be
<img width="386" height="821" alt="image" src="https://github.com/user-attachments/assets/4c83808d-1b35-452d-b8e0-d02cf41a8b71" />


```
 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')' at line 1
```